### PR TITLE
Remove the custom docker.sh script

### DIFF
--- a/app/uk/gov/hmrc/emcstfereferencedata/config/Module.scala
+++ b/app/uk/gov/hmrc/emcstfereferencedata/config/Module.scala
@@ -16,8 +16,7 @@
 
 package uk.gov.hmrc.emcstfereferencedata.config
 
-import com.google.inject.{AbstractModule, Inject, Singleton}
-import play.api.{Configuration, Environment}
+import com.google.inject.{AbstractModule, Singleton}
 import uk.gov.hmrc.emcstfereferencedata.connector.retrieveAllCNCodes.{
   RetrieveAllCNCodesConnector,
   RetrieveAllCNCodesConnectorCRDL
@@ -42,8 +41,7 @@ import uk.gov.hmrc.emcstfereferencedata.connector.retrieveProductCodes.{
 import uk.gov.hmrc.emcstfereferencedata.controllers.predicates.{AuthAction, AuthActionImpl}
 
 @Singleton
-class Module @Inject() (environment: Environment, config: Configuration) extends AbstractModule {
-
+class Module extends AbstractModule {
   override def configure(): Unit = {
     bind(classOf[AppConfig]).asEagerSingleton()
     bind(classOf[AuthAction]).to(classOf[AuthActionImpl])

--- a/start-docker.sh
+++ b/start-docker.sh
@@ -1,9 +1,0 @@
-#!/bin/sh
-
-# Add the server certificate used to authenticate the other party.
-if [ -n "${HMRC_TRUSTSTORE}" ] ; then
-  echo $HMRC_TRUSTSTORE | base64 --decode > /app/hmrc_truststore.jks
-fi
-
-SCRIPT=$(find . -type f -name emcs-tfe-reference-data)
-exec $SCRIPT $HMRC_CONFIG -Dconfig.file=conf/emcs-tfe-reference-data.conf


### PR DESCRIPTION
This PR removes the custom start-docker.sh script that used to be used to supply trust store config.

It also uses the simpler constructor for the application's Module since we don't make use of the constructor parameters.