### PR TITLE
CRDL-337 Implement a daily migration job which rebuilds the reference data collections

### DIFF
--- a/app/uk/gov/hmrc/emcstfereferencedata/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/emcstfereferencedata/config/AppConfig.scala
@@ -25,4 +25,5 @@ import javax.inject.{Inject, Singleton}
 class AppConfig @Inject() (val config: Configuration, servicesConfig: ServicesConfig) {
   lazy val crdlCacheUrl: String  = servicesConfig.baseUrl("crdl-cache")
   lazy val crdlCachePath: String = config.get[String]("microservice.services.crdl-cache.path")
+  lazy val importRefDataSchedule: String = config.get[String]("import-reference-data.schedule")
 }

--- a/app/uk/gov/hmrc/emcstfereferencedata/config/Module.scala
+++ b/app/uk/gov/hmrc/emcstfereferencedata/config/Module.scala
@@ -17,27 +17,12 @@
 package uk.gov.hmrc.emcstfereferencedata.config
 
 import com.google.inject.{AbstractModule, Singleton}
-import uk.gov.hmrc.emcstfereferencedata.connector.retrieveAllCNCodes.{
-  RetrieveAllCNCodesConnector,
-  RetrieveAllCNCodesConnectorCRDL
-}
-import uk.gov.hmrc.emcstfereferencedata.connector.retrieveAllEPCCodes.{
-  RetrieveAllEPCCodesConnector,
-  RetrieveAllEPCCodesConnectorCRDL
-}
+import uk.gov.hmrc.emcstfereferencedata.connector.retrieveAllCNCodes.{RetrieveAllCNCodesConnector, RetrieveAllCNCodesConnectorCRDL}
+import uk.gov.hmrc.emcstfereferencedata.connector.retrieveAllEPCCodes.{RetrieveAllEPCCodesConnector, RetrieveAllEPCCodesConnectorCRDL}
 import uk.gov.hmrc.emcstfereferencedata.connector.retrieveCnCodeInformation.*
-import uk.gov.hmrc.emcstfereferencedata.connector.retrieveOtherReferenceData.{
-  RetrieveOtherReferenceDataConnector,
-  RetrieveOtherReferenceDataConnectorCRDL
-}
-import uk.gov.hmrc.emcstfereferencedata.connector.retrievePackagingTypes.{
-  RetrievePackagingTypesConnector,
-  RetrievePackagingTypesConnectorCRDL
-}
-import uk.gov.hmrc.emcstfereferencedata.connector.retrieveProductCodes.{
-  RetrieveProductCodesConnector,
-  RetrieveProductCodesConnectorCRDL
-}
+import uk.gov.hmrc.emcstfereferencedata.connector.retrieveOtherReferenceData.{RetrieveOtherReferenceDataConnector, RetrieveOtherReferenceDataConnectorCRDL}
+import uk.gov.hmrc.emcstfereferencedata.connector.retrievePackagingTypes.{RetrievePackagingTypesConnector, RetrievePackagingTypesConnectorCRDL}
+import uk.gov.hmrc.emcstfereferencedata.connector.retrieveProductCodes.{RetrieveProductCodesConnector, RetrieveProductCodesConnectorCRDL}
 import uk.gov.hmrc.emcstfereferencedata.controllers.predicates.{AuthAction, AuthActionImpl}
 
 @Singleton

--- a/app/uk/gov/hmrc/emcstfereferencedata/config/SchedulerModule.scala
+++ b/app/uk/gov/hmrc/emcstfereferencedata/config/SchedulerModule.scala
@@ -14,16 +14,19 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.emcstfereferencedata.models.crdl
+package uk.gov.hmrc.emcstfereferencedata.config
 
-import play.api.libs.json.{Format, Json}
+import com.google.inject.AbstractModule
+import org.quartz.SchedulerFactory
+import org.quartz.impl.StdSchedulerFactory
+import uk.gov.hmrc.emcstfereferencedata.scheduler.JobScheduler
 
-case class CodeListCode(value: String) extends AnyVal
+import javax.inject.Singleton
 
-object CodeListCode {
-  given Format[CodeListCode] = Json.valueFormat[CodeListCode]
-  val BC36: CodeListCode = CodeListCode("BC36")
-  val BC37: CodeListCode = CodeListCode("BC37")
-  val BC66: CodeListCode = CodeListCode("BC66")
-  val E200: CodeListCode = CodeListCode("E200")
+@Singleton
+class SchedulerModule extends AbstractModule {
+  override def configure(): Unit = {
+    bind(classOf[JobScheduler]).asEagerSingleton()
+    bind(classOf[SchedulerFactory]).toInstance(new StdSchedulerFactory())
+  }
 }

--- a/app/uk/gov/hmrc/emcstfereferencedata/connector/crdl/CrdlConnector.scala
+++ b/app/uk/gov/hmrc/emcstfereferencedata/connector/crdl/CrdlConnector.scala
@@ -25,9 +25,10 @@ import uk.gov.hmrc.http.HttpReads.Implicits.*
 import uk.gov.hmrc.http.UpstreamErrorResponse.{Upstream4xxResponse, Upstream5xxResponse}
 import uk.gov.hmrc.http.client.HttpClientV2
 
-import javax.inject.Inject
+import javax.inject.{Inject, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
 
+@Singleton
 class CrdlConnector @Inject() (config: AppConfig, httpClient: HttpClientV2)(using
   system: ActorSystem
 ) extends Retries {

--- a/app/uk/gov/hmrc/emcstfereferencedata/repositories/CnCodesRepository.scala
+++ b/app/uk/gov/hmrc/emcstfereferencedata/repositories/CnCodesRepository.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.emcstfereferencedata.repositories
 
-import org.mongodb.scala.{model, *}
+import org.mongodb.scala.*
 import org.mongodb.scala.bson.conversions.Bson
 import org.mongodb.scala.model.Filters.*
 import org.mongodb.scala.model.Sorts.*
@@ -60,6 +60,19 @@ class CnCodesRepository @Inject() (val mongoComponent: MongoComponent)(using
         if (!result.wasAcknowledged())
           throw MongoError.NotAcknowledged
       }
+
+  def saveCnCodes(
+    session: ClientSession,
+    cnCodes: Seq[CnCodeInformation]
+  ): Future[Unit] =
+    for {
+      _ <- deleteCnCodes(session)
+
+      _ <- collection.insertMany(session, cnCodes).toFuture().map { result =>
+        if (!result.wasAcknowledged())
+          throw MongoError.NotAcknowledged
+      }
+    } yield ()
 
   def fetchCnCodesForProduct(exciseProductCode: String): Future[Seq[CnCodeInformation]] =
     collection

--- a/app/uk/gov/hmrc/emcstfereferencedata/repositories/ExciseProductsRepository.scala
+++ b/app/uk/gov/hmrc/emcstfereferencedata/repositories/ExciseProductsRepository.scala
@@ -60,7 +60,7 @@ class ExciseProductsRepository @Inject() (val mongoComponent: MongoComponent)(us
 
   def saveExciseProducts(
     session: ClientSession,
-    exciseProducts: List[ExciseProductCode]
+    exciseProducts: Seq[ExciseProductCode]
   ): Future[Unit] =
     for {
       _ <- deleteExciseProducts(session)

--- a/app/uk/gov/hmrc/emcstfereferencedata/scheduler/JobScheduler.scala
+++ b/app/uk/gov/hmrc/emcstfereferencedata/scheduler/JobScheduler.scala
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.emcstfereferencedata.scheduler
+
+import org.quartz.JobBuilder.newJob
+import org.quartz.TriggerBuilder.newTrigger
+import org.quartz.impl.StdSchedulerFactory
+import org.quartz.{CronScheduleBuilder, Scheduler, SchedulerFactory, Trigger}
+import play.api.Logging
+import play.api.inject.ApplicationLifecycle
+import uk.gov.hmrc.emcstfereferencedata.config.AppConfig
+import uk.gov.hmrc.emcstfereferencedata.scheduler.jobs.ImportReferenceDataJob
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
+
+@Singleton
+class JobScheduler @Inject()(
+  lifecycle: ApplicationLifecycle,
+  schedulerFactory: SchedulerFactory,
+  jobFactory: ScheduledJobFactory,
+  config: AppConfig
+)(using
+  ec: ExecutionContext
+) extends Logging {
+  private val quartz: Scheduler = schedulerFactory.getScheduler
+
+  private val refDataJobDetail = newJob(classOf[ImportReferenceDataJob])
+    .withIdentity("import-reference-data")
+    .build()
+
+  private val refDataJobSchedule = CronScheduleBuilder
+    .cronSchedule(config.importRefDataSchedule)
+
+  private val refDataJobTrigger = newTrigger()
+    .forJob(refDataJobDetail)
+    .withSchedule(refDataJobSchedule)
+    .build()
+
+  private def getJobStatus(trigger: Trigger): JobStatus =
+    JobStatus(quartz.getTriggerState(trigger.getKey))
+
+  def startReferenceDataImport(): Unit = {
+    quartz.triggerJob(refDataJobDetail.getKey)
+  }
+
+  def referenceDataImportStatus(): JobStatus = {
+    getJobStatus(refDataJobTrigger)
+  }
+
+  private def startScheduler(): Unit = {
+    val quartz = StdSchedulerFactory.getDefaultScheduler
+
+    quartz.setJobFactory(jobFactory)
+
+    lifecycle.addStopHook(() => Future(quartz.shutdown()))
+
+    quartz.scheduleJob(refDataJobDetail, refDataJobTrigger)
+    quartz.start()
+  }
+
+  startScheduler()
+}

--- a/app/uk/gov/hmrc/emcstfereferencedata/scheduler/JobStatus.scala
+++ b/app/uk/gov/hmrc/emcstfereferencedata/scheduler/JobStatus.scala
@@ -14,16 +14,19 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.emcstfereferencedata.models.crdl
+package uk.gov.hmrc.emcstfereferencedata.scheduler
 
-import play.api.libs.json.{Format, Json}
+import org.quartz.Trigger.TriggerState
+import play.api.libs.json.{JsString, Json, Writes}
 
-case class CodeListCode(value: String) extends AnyVal
+case class JobStatus(status: TriggerState)
 
-object CodeListCode {
-  given Format[CodeListCode] = Json.valueFormat[CodeListCode]
-  val BC36: CodeListCode = CodeListCode("BC36")
-  val BC37: CodeListCode = CodeListCode("BC37")
-  val BC66: CodeListCode = CodeListCode("BC66")
-  val E200: CodeListCode = CodeListCode("E200")
+object JobStatus {
+  given Writes[TriggerState] = {
+    case TriggerState.BLOCKED => JsString("RUNNING")
+    case TriggerState.NORMAL  => JsString("IDLE")
+    case other                => JsString(other.toString)
+  }
+
+  given Writes[JobStatus] = Json.writes[JobStatus]
 }

--- a/app/uk/gov/hmrc/emcstfereferencedata/scheduler/ScheduledJobFactory.scala
+++ b/app/uk/gov/hmrc/emcstfereferencedata/scheduler/ScheduledJobFactory.scala
@@ -14,16 +14,17 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.emcstfereferencedata.models.crdl
+package uk.gov.hmrc.emcstfereferencedata.scheduler
 
-import play.api.libs.json.{Format, Json}
+import org.quartz
+import org.quartz.Job
+import org.quartz.spi.{JobFactory, TriggerFiredBundle}
+import play.api.inject.Injector
 
-case class CodeListCode(value: String) extends AnyVal
+import javax.inject.{Inject, Singleton}
 
-object CodeListCode {
-  given Format[CodeListCode] = Json.valueFormat[CodeListCode]
-  val BC36: CodeListCode = CodeListCode("BC36")
-  val BC37: CodeListCode = CodeListCode("BC37")
-  val BC66: CodeListCode = CodeListCode("BC66")
-  val E200: CodeListCode = CodeListCode("E200")
+@Singleton
+class ScheduledJobFactory @Inject()(injector: Injector) extends JobFactory {
+  override def newJob(bundle: TriggerFiredBundle, scheduler: quartz.Scheduler): Job =
+    injector.instanceOf(bundle.getJobDetail.getJobClass)
 }

--- a/app/uk/gov/hmrc/emcstfereferencedata/scheduler/jobs/ImportReferenceDataJob.scala
+++ b/app/uk/gov/hmrc/emcstfereferencedata/scheduler/jobs/ImportReferenceDataJob.scala
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.emcstfereferencedata.scheduler.jobs
+
+import org.mongodb.scala.ClientSession
+import org.quartz.{DisallowConcurrentExecution, Job, JobExecutionContext}
+import uk.gov.hmrc.emcstfereferencedata.connector.crdl.CrdlConnector
+import uk.gov.hmrc.emcstfereferencedata.models.crdl.CodeListCode
+import uk.gov.hmrc.emcstfereferencedata.models.crdl.CodeListCode.{BC36, BC37, BC66, E200}
+import uk.gov.hmrc.emcstfereferencedata.repositories.{
+  CnCodesRepository,
+  CodeListsRepository,
+  ExciseProductsRepository
+}
+import uk.gov.hmrc.emcstfereferencedata.utils.Logging
+import uk.gov.hmrc.mongo.MongoComponent
+import uk.gov.hmrc.mongo.lock.{LockService, MongoLockRepository}
+import uk.gov.hmrc.mongo.transaction.{TransactionConfiguration, Transactions}
+
+import javax.inject.Inject
+import scala.concurrent.duration.*
+import scala.concurrent.{Await, ExecutionContext, Future}
+
+@DisallowConcurrentExecution
+class ImportReferenceDataJob @Inject() (
+  val mongoComponent: MongoComponent,
+  val lockRepository: MongoLockRepository,
+  crdlConnector: CrdlConnector,
+  codeListsRepository: CodeListsRepository,
+  cnCodesRepository: CnCodesRepository,
+  exciseProductsRepository: ExciseProductsRepository
+)(using ec: ExecutionContext)
+  extends Job
+  with LockService
+  with Logging
+  with Transactions {
+
+  private val jobName = "import-reference-data"
+
+  given TransactionConfiguration = TransactionConfiguration.strict
+
+  override val lockId: String = jobName
+  override val ttl: Duration  = 1.hour
+
+  private def refreshCodeListEntries(session: ClientSession, codeListCode: CodeListCode) =
+    for {
+      entries <- crdlConnector.fetchCodeList(codeListCode)
+      _       <- codeListsRepository.saveCodeListEntries(session, codeListCode, entries)
+    } yield ()
+
+  private def rebuildExciseProducts(
+    session: ClientSession,
+    saveExciseProducts: Future[Unit]
+  ): Future[Unit] = {
+    val saveProductCategories = refreshCodeListEntries(session, BC66)
+
+    for {
+      // We need both BC36 and BC66 data to build the excise-products collection
+      _ <- saveExciseProducts
+      _ <- saveProductCategories
+
+      exciseProducts <- codeListsRepository.buildExciseProducts(session)
+      _              <- exciseProductsRepository.saveExciseProducts(session, exciseProducts)
+
+    } yield ()
+  }
+
+  private def rebuildCnCodes(
+    session: ClientSession,
+    saveExciseProducts: Future[Unit]
+  ): Future[Unit] = {
+    val saveCnCodes         = refreshCodeListEntries(session, BC37)
+    val saveCorrespondences = refreshCodeListEntries(session, E200)
+
+    for {
+      // We need E200, BC36 and BC37 data to build the cn-codes collection
+      _ <- saveCorrespondences
+      _ <- saveExciseProducts
+      _ <- saveCnCodes
+
+      cnCodeInfo <- codeListsRepository.buildCnCodes(session)
+      _          <- cnCodesRepository.saveCnCodes(session, cnCodeInfo)
+
+    } yield ()
+  }
+
+  private[jobs] def importReferenceData(): Future[Unit] = {
+    val importRefData = withSessionAndTransaction { session =>
+      // BC36 data is used by both of the derived collections
+      val saveExciseProducts = refreshCodeListEntries(session, BC36)
+      val cnCodes            = rebuildCnCodes(session, saveExciseProducts)
+      val exciseProducts     = rebuildExciseProducts(session, saveExciseProducts)
+      cnCodes.zip(exciseProducts).map(_ => ())
+    }
+
+    importRefData.foreach(_ => logger.info(s"${jobName} job completed successfully"))
+    importRefData.failed.foreach(err => logger.error(s"${jobName} job failed", err))
+
+    importRefData
+  }
+
+  override def execute(context: JobExecutionContext): Unit =
+    Await.result(
+      withLock(importReferenceData()).map {
+        _.getOrElse {
+          logger.info(s"${jobName} job lock could not be obtained")
+        }
+      },
+      Duration.Inf
+    )
+}

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -27,7 +27,7 @@ play.http.errorHandler = "uk.gov.hmrc.play.bootstrap.backend.http.JsonErrorHandl
 
 # Play Modules
 play.modules.enabled += "uk.gov.hmrc.emcstfereferencedata.config.Module"
-
+play.modules.enabled += "uk.gov.hmrc.emcstfereferencedata.config.SchedulerModule"
 play.modules.enabled += "uk.gov.hmrc.mongo.play.PlayMongoModule"
 
 # Auth Module
@@ -62,6 +62,10 @@ controllers {
 # Microservice specific config
 mongodb {
   uri = "mongodb://localhost:27017/emcs-tfe-crdl-reference-data"
+}
+
+import-reference-data {
+  schedule = "0 30 4 * * ?"
 }
 
 microservice {

--- a/conf/testOnlyDoNotUseInAppConf.routes
+++ b/conf/testOnlyDoNotUseInAppConf.routes
@@ -12,6 +12,8 @@
 # Add all the application routes to the prod.routes file
 ->        /        prod.Routes
 
+GET           /emcs-tfe-reference-data/test-only/reference-data           uk.gov.hmrc.emcstfereferencedata.controllers.testonly.TestOnlyController.referenceDataImportStatus()
+POST          /emcs-tfe-reference-data/test-only/reference-data           uk.gov.hmrc.emcstfereferencedata.controllers.testonly.TestOnlyController.importReferenceData()
 DELETE        /emcs-tfe-reference-data/test-only/codelists                uk.gov.hmrc.emcstfereferencedata.controllers.testonly.TestOnlyController.deleteCodeLists()
 DELETE        /emcs-tfe-reference-data/test-only/excise-products          uk.gov.hmrc.emcstfereferencedata.controllers.testonly.TestOnlyController.deleteExciseProducts()
 DELETE        /emcs-tfe-reference-data/test-only/cn-codes                 uk.gov.hmrc.emcstfereferencedata.controllers.testonly.TestOnlyController.deleteCnCodes()

--- a/it/test/uk/gov/hmrc/emcstfereferencedata/controllers/ControllerIntegrationSpec.scala
+++ b/it/test/uk/gov/hmrc/emcstfereferencedata/controllers/ControllerIntegrationSpec.scala
@@ -22,7 +22,10 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
+import play.api.Application
+import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.ws.JsonBodyWritables
+import uk.gov.hmrc.emcstfereferencedata.config.SchedulerModule
 import uk.gov.hmrc.http.test.HttpClientV2Support
 import uk.gov.hmrc.http.{HeaderCarrier, HttpReadsInstances}
 import uk.gov.hmrc.http.StringContextOps
@@ -47,4 +50,11 @@ trait ControllerIntegrationSpec
 
   // FIXME: We are maintaining the context path of the old emcs-tfe-reference-data service because it is hardcoded into the TFE frontends
   protected def baseUrl = url"http://localhost:$port/emcs-tfe-reference-data"
+
+  override def fakeApplication(): Application = {
+    GuiceApplicationBuilder()
+      // Stop Quartz from complaining about being instantiated multiple times
+      .disable(classOf[SchedulerModule])
+      .build()
+  }
 }

--- a/it/test/uk/gov/hmrc/emcstfereferencedata/repositories/CnCodesRepositorySpec.scala
+++ b/it/test/uk/gov/hmrc/emcstfereferencedata/repositories/CnCodesRepositorySpec.scala
@@ -118,4 +118,75 @@ class CnCodesRepositorySpec
       )
     }
   }
+
+  "CnCodesRepository.saveCnCodes" should {
+    "save new CN codes" in {
+      val cnCodes = List(
+        CnCodeInformation(
+          "22060059",
+          "Other still fermented beverages in containers holding 2 litres or less",
+          "B000",
+          "Beer",
+          unitOfMeasureCode = 3
+        ),
+        CnCodeInformation(
+          "22060059",
+          "Other still fermented beverages in containers holding 2 litres or less",
+          "I000",
+          "Intermediate products",
+          unitOfMeasureCode = 3
+        ),
+      )
+
+      withSessionAndTransaction { repository.saveCnCodes(_, cnCodes) }.futureValue
+
+      val insertedEntries = repository.collection.find().toFuture().futureValue
+
+      insertedEntries should contain theSameElementsAs cnCodes
+    }
+
+    "remove existing CN codes when new CN codes are saved" in {
+      val existingCnCodes = List(
+        CnCodeInformation(
+          "22060059",
+          "Other still fermented beverages in containers holding 2 litres or less",
+          "B000",
+          "Beer",
+          unitOfMeasureCode = 3
+        ),
+        CnCodeInformation(
+          "22060059",
+          "Other still fermented beverages in containers holding 2 litres or less",
+          "I000",
+          "Intermediate products",
+          unitOfMeasureCode = 3
+        ),
+      )
+
+      repository.collection.insertMany(existingCnCodes).toFuture().futureValue
+
+      val newCnCodes = List(
+        CnCodeInformation(
+          "27101944",
+          "Other heavy gas oils for other purposes with a sulphur content not exceeding 0,001% by weight.",
+          "E430",
+          "Gasoil, unmarked falling within CN codes 2710 19 42, 2710 19 44, 2710 19 46, 2710 19 47, 2710 19 48, 2710 20 11, 2710 20 16 and 2710 20 19 (Article 20(1)(c) of Directive 2003/96/EC)",
+          unitOfMeasureCode = 2
+        ),
+        CnCodeInformation(
+          "27101944",
+          "Other heavy gas oils for other purposes with a sulphur content not exceeding 0,001% by weight.",
+          "E440",
+          "Gasoil, marked falling within CN codes 2710 19 42, 2710 19 44, 2710 19 46, 2710 19 47, 2710 19 48, 2710 20 11, 2710 20 16 and 2710 20 19 (Article 20(1)(c) of Directive 2003/96/EC)",
+          unitOfMeasureCode = 2
+        )
+      )
+
+      withSessionAndTransaction { repository.saveCnCodes(_, newCnCodes) }.futureValue
+
+      val insertedEntries = findAll().futureValue
+
+      insertedEntries should contain theSameElementsAs newCnCodes
+    }
+  }
 }

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -5,15 +5,17 @@ object AppDependencies {
 
   val playSuffix = "-play-30"
 
-  val hmrcBootstrapVersion = "9.13.0"
+  val hmrcBootstrapVersion = "9.14.0"
   val hmrcMongoVersion     = "2.6.0"
-  val scalamockVersion     = "7.3.2"
+  val scalamockVersion     = "7.4.0"
   val catsCoreVersion      = "2.13.0"
+  val quartzVersion        = "2.5.0"
 
   private val compile = Seq(
-    "uk.gov.hmrc"       %% s"bootstrap-backend$playSuffix" % hmrcBootstrapVersion,
-    "uk.gov.hmrc.mongo" %% s"hmrc-mongo$playSuffix"        % hmrcMongoVersion,
-    "org.typelevel"     %% "cats-core"                     % catsCoreVersion
+    "uk.gov.hmrc"         %% s"bootstrap-backend$playSuffix" % hmrcBootstrapVersion,
+    "uk.gov.hmrc.mongo"   %% s"hmrc-mongo$playSuffix"        % hmrcMongoVersion,
+    "org.typelevel"       %% "cats-core"                     % catsCoreVersion,
+    "org.quartz-scheduler" % "quartz"                        % quartzVersion
   )
 
   private val test = Seq(

--- a/test/uk/gov/hmrc/emcstfereferencedata/scheduler/JobSchedulerSpec.scala
+++ b/test/uk/gov/hmrc/emcstfereferencedata/scheduler/JobSchedulerSpec.scala
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.emcstfereferencedata.scheduler
+
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.when
+import org.quartz.Trigger.TriggerState
+import org.quartz.impl.StdSchedulerFactory
+import org.quartz.{Job, SchedulerFactory}
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.concurrent.Eventually
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.must.Matchers
+import org.scalatestplus.mockito.MockitoSugar
+import play.api.inject.ApplicationLifecycle
+import uk.gov.hmrc.emcstfereferencedata.config.AppConfig
+
+import scala.concurrent.ExecutionContext
+
+class JobSchedulerSpec
+  extends AnyFlatSpec
+  with Matchers
+  with MockitoSugar
+  with BeforeAndAfterEach
+  with Eventually {
+  given ExecutionContext = ExecutionContext.global
+
+  private val schedulerFactory: SchedulerFactory = new StdSchedulerFactory()
+  private var lifecycle: ApplicationLifecycle    = _
+  private var jobFactory: ScheduledJobFactory    = _
+  private var appConfig: AppConfig               = _
+  private var jobScheduler: JobScheduler         = _
+
+  override def beforeEach(): Unit = {
+    // Clear down any job or schedule information
+    schedulerFactory.getScheduler.clear()
+
+    lifecycle = mock[ApplicationLifecycle]
+    jobFactory = mock[ScheduledJobFactory]
+    appConfig = mock[AppConfig]
+
+    when(appConfig.importRefDataSchedule).thenReturn("0 0 4 * * ? 2099")
+    when(jobFactory.newJob(any(), any())).thenReturn(_ => Thread.sleep(50))
+
+    jobScheduler = new JobScheduler(lifecycle, schedulerFactory, jobFactory, appConfig)
+  }
+
+  "JobScheduler.referenceDataImportStatus" should "return trigger status NORMAL when the job is not running" in {
+    jobScheduler.referenceDataImportStatus() mustBe JobStatus(TriggerState.NORMAL)
+  }
+
+  it should "return the status BLOCKED when the job is running" in {
+    jobScheduler.startReferenceDataImport()
+    // Trigger state should go to blocked while the job is running
+    eventually {
+      jobScheduler.referenceDataImportStatus() mustBe JobStatus(TriggerState.BLOCKED)
+    }
+    // It should return to normal once the job ends
+    eventually {
+      jobScheduler.referenceDataImportStatus() mustBe JobStatus(TriggerState.NORMAL)
+    }
+  }
+}

--- a/test/uk/gov/hmrc/emcstfereferencedata/scheduler/JobStatusSpec.scala
+++ b/test/uk/gov/hmrc/emcstfereferencedata/scheduler/JobStatusSpec.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.emcstfereferencedata.scheduler
+
+import org.quartz.Trigger.TriggerState
+import org.scalatest.Inspectors
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import play.api.libs.json.Json
+
+class JobStatusSpec extends AnyWordSpec with Matchers with Inspectors {
+  private val triggerStates = TriggerState.values()
+    .filterNot(Set(TriggerState.NORMAL, TriggerState.BLOCKED))
+
+  "JobStatus" should {
+    "serialize TriggerState.NORMAL as IDLE" in {
+      Json.toJson(JobStatus(TriggerState.NORMAL)) shouldBe Json.obj("status" -> "IDLE")
+    }
+
+    "serialize TriggerState.BLOCKED as RUNNING" in {
+      Json.toJson(JobStatus(TriggerState.BLOCKED)) shouldBe Json.obj("status" -> "RUNNING")
+    }
+
+    "serialize other statuses as their names" in forEvery(triggerStates) { state =>
+      Json.toJson(JobStatus(state)) shouldBe Json.obj("status" -> state.toString)
+    }
+  }
+}

--- a/test/uk/gov/hmrc/emcstfereferencedata/scheduler/ScheduledJobFactorySpec.scala
+++ b/test/uk/gov/hmrc/emcstfereferencedata/scheduler/ScheduledJobFactorySpec.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.emcstfereferencedata.scheduler
+
+import org.mockito.Mockito.when
+import org.quartz.spi.TriggerFiredBundle
+import org.quartz.{JobDetail, Scheduler}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.must.Matchers
+import org.scalatestplus.mockito.MockitoSugar
+import play.api.inject.Injector
+import uk.gov.hmrc.emcstfereferencedata.scheduler.jobs.ImportReferenceDataJob
+
+class ScheduledJobFactorySpec extends AnyFlatSpec with Matchers with MockitoSugar {
+  "ScheduledJobFactory" should "instantiate jobs using Play Framework's Guice injector" in {
+    val bundle    = mock[TriggerFiredBundle]
+    val jobDetail = mock[JobDetail]
+    when(bundle.getJobDetail).thenReturn(jobDetail)
+    when(jobDetail.getJobClass).thenReturn(classOf[ImportReferenceDataJob])
+
+    val injector = mock[Injector]
+    val job      = mock[ImportReferenceDataJob]
+    when(injector.instanceOf(classOf[ImportReferenceDataJob])).thenReturn(job)
+
+    val scheduler = mock[Scheduler]
+    val factory   = new ScheduledJobFactory(injector)
+    val result    = factory.newJob(bundle, scheduler)
+
+    result mustBe job
+  }
+}

--- a/test/uk/gov/hmrc/emcstfereferencedata/scheduler/jobs/ImportReferenceDataJobSpec.scala
+++ b/test/uk/gov/hmrc/emcstfereferencedata/scheduler/jobs/ImportReferenceDataJobSpec.scala
@@ -1,0 +1,386 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.emcstfereferencedata.scheduler.jobs
+
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.stream.scaladsl.{Sink, Source}
+import org.mockito.ArgumentMatchers.{any, eq as equalTo}
+import org.mockito.Mockito.*
+import org.mongodb.scala.{ClientSession, MongoClient, MongoDatabase, SingleObservable}
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.mockito.MockitoSugar
+import play.api.http.Status
+import play.api.libs.json.Json
+import uk.gov.hmrc.emcstfereferencedata.config.AppConfig
+import uk.gov.hmrc.emcstfereferencedata.connector.crdl.CrdlConnector
+import uk.gov.hmrc.emcstfereferencedata.models.crdl.{CodeListCode, CrdlCodeListEntry}
+import uk.gov.hmrc.emcstfereferencedata.models.errors.MongoError
+import uk.gov.hmrc.emcstfereferencedata.models.response.{CnCodeInformation, ExciseProductCode}
+import uk.gov.hmrc.emcstfereferencedata.repositories.{
+  CnCodesRepository,
+  CodeListsRepository,
+  ExciseProductsRepository
+}
+import uk.gov.hmrc.http.UpstreamErrorResponse
+import uk.gov.hmrc.mongo.MongoComponent
+import uk.gov.hmrc.mongo.lock.{Lock, MongoLockRepository}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class ImportReferenceDataJobSpec
+  extends AnyFlatSpec
+  with Matchers
+  with MockitoSugar
+  with ScalaFutures
+  with IntegrationPatience
+  with BeforeAndAfterEach {
+
+  private val mongoComponent           = mock[MongoComponent]
+  private val mongoClient              = mock[MongoClient]
+  private val mongoDatabase            = mock[MongoDatabase]
+  private val clientSession            = mock[ClientSession]
+  private val lockRepository           = mock[MongoLockRepository]
+  private val codeListsRepository      = mock[CodeListsRepository]
+  private val cnCodesRepository        = mock[CnCodesRepository]
+  private val exciseProductsRepository = mock[ExciseProductsRepository]
+  private val crdlConnector            = mock[CrdlConnector]
+  private val appConfig                = mock[AppConfig]
+
+  given ActorSystem      = ActorSystem("test")
+  given ExecutionContext = ExecutionContext.global
+
+  private val refDataJob = new ImportReferenceDataJob(
+    mongoComponent,
+    lockRepository,
+    crdlConnector,
+    codeListsRepository,
+    cnCodesRepository,
+    exciseProductsRepository
+  )
+
+  private val BC36Entries = List(
+    CrdlCodeListEntry(
+      "B000",
+      "Beer",
+      Json.obj(
+        "unitOfMeasureCode"                  -> "3",
+        "degreePlatoApplicabilityFlag"       -> true,
+        "actionIdentification"               -> "1090",
+        "exciseProductsCategoryCode"         -> "B",
+        "alcoholicStrengthApplicabilityFlag" -> true,
+        "densityApplicabilityFlag"           -> false
+      )
+    ),
+    CrdlCodeListEntry(
+      "I000",
+      "Intermediate products",
+      Json.obj(
+        "unitOfMeasureCode"                  -> "3",
+        "degreePlatoApplicabilityFlag"       -> true,
+        "actionIdentification"               -> "1109",
+        "exciseProductsCategoryCode"         -> "I",
+        "alcoholicStrengthApplicabilityFlag" -> true,
+        "densityApplicabilityFlag"           -> false
+      )
+    )
+  )
+
+  private val BC37Entries = List(
+    CrdlCodeListEntry(
+      "22060059",
+      "Other still fermented beverages in containers holding 2 litres or less",
+      Json.obj("actionIdentification" -> "323")
+    )
+  )
+
+  private val BC66Entries = List(
+    CrdlCodeListEntry(
+      "B",
+      "Beer",
+      Json.obj("actionIdentification" -> "1084")
+    ),
+    CrdlCodeListEntry(
+      "I",
+      "Intermediate products",
+      Json.obj("actionIdentification" -> "1086")
+    )
+  )
+
+  private val E200Entries = Seq(
+    CrdlCodeListEntry(
+      "22060059",
+      "B000",
+      Json.obj("actionIdentification" -> "355")
+    ),
+    CrdlCodeListEntry(
+      "22060059",
+      "I000",
+      Json.obj("actionIdentification" -> "526")
+    )
+  )
+
+  private val CnCodes = List(
+    CnCodeInformation(
+      "22060059",
+      "Other still fermented beverages in containers holding 2 litres or less",
+      "B000",
+      "Beer",
+      unitOfMeasureCode = 3
+    ),
+    CnCodeInformation(
+      "22060059",
+      "Other still fermented beverages in containers holding 2 litres or less",
+      "I000",
+      "Intermediate products",
+      unitOfMeasureCode = 3
+    )
+  )
+
+  private val ExciseProducts = List(
+    ExciseProductCode(
+      "B000",
+      "Beer",
+      "B",
+      "Beer"
+    ),
+    ExciseProductCode(
+      "I000",
+      "Intermediate products",
+      "I",
+      "Intermediate products"
+    )
+  )
+
+  override def beforeEach(): Unit = {
+    reset(
+      mongoComponent,
+      mongoClient,
+      mongoDatabase,
+      clientSession,
+      lockRepository,
+      cnCodesRepository,
+      exciseProductsRepository,
+      codeListsRepository,
+      crdlConnector,
+      appConfig
+    )
+
+    // Job lock
+    val mockLock = mock[Lock]
+    when(lockRepository.takeLock(any(), any(), any())).thenReturn(Future.successful(Some(mockLock)))
+    when(lockRepository.releaseLock(any(), any())).thenReturn(Future.unit)
+
+    // Transactions
+    when(mongoComponent.client).thenReturn(mongoClient)
+    when(mongoComponent.database).thenReturn(mongoDatabase)
+    when(mongoClient.startSession(any())).thenReturn(SingleObservable(clientSession))
+    when(clientSession.commitTransaction())
+      .thenAnswer(_ => Source.empty[Void].runWith(Sink.asPublisher(fanout = false)))
+    when(clientSession.abortTransaction())
+      .thenAnswer(_ => Source.empty[Void].runWith(Sink.asPublisher(fanout = false)))
+  }
+
+  "ImportReferenceDataJob.importReferenceData" should "import the configured codelists and build the derived domain objects" in {
+    // CRDL connector responses
+    when(crdlConnector.fetchCodeList(CodeListCode(equalTo("BC36")))(using any()))
+      .thenReturn(Future.successful(BC36Entries))
+    when(crdlConnector.fetchCodeList(CodeListCode(equalTo("BC37")))(using any()))
+      .thenReturn(Future.successful(BC37Entries))
+    when(crdlConnector.fetchCodeList(CodeListCode(equalTo("BC66")))(using any()))
+      .thenReturn(Future.successful(BC66Entries))
+    when(crdlConnector.fetchCodeList(CodeListCode(equalTo("E200")))(using any()))
+      .thenReturn(Future.successful(E200Entries))
+
+    // Mongo collection manipulation
+    when(codeListsRepository.saveCodeListEntries(equalTo(clientSession), any(), any()))
+      .thenReturn(Future.unit)
+    when(codeListsRepository.buildCnCodes(equalTo(clientSession)))
+      .thenReturn(Future.successful(CnCodes))
+    when(codeListsRepository.buildExciseProducts(equalTo(clientSession)))
+      .thenReturn(Future.successful(ExciseProducts))
+    when(exciseProductsRepository.saveExciseProducts(equalTo(clientSession), any()))
+      .thenReturn(Future.unit)
+    when(cnCodesRepository.saveCnCodes(equalTo(clientSession), any())).thenReturn(Future.unit)
+
+    refDataJob.importReferenceData().futureValue
+
+    verify(codeListsRepository, times(4)).saveCodeListEntries(equalTo(clientSession), any(), any())
+    verify(cnCodesRepository, times(1)).saveCnCodes(equalTo(clientSession), any())
+    verify(exciseProductsRepository, times(1)).saveExciseProducts(equalTo(clientSession), any())
+
+    verify(clientSession, times(1)).commitTransaction()
+  }
+
+  it should "roll back and fail to build excise products when there is an issue fetching one of the required codelists" in {
+    // CRDL connector responses
+    when(crdlConnector.fetchCodeList(CodeListCode(equalTo("BC36")))(using any()))
+      .thenReturn(Future.successful(BC36Entries))
+    when(crdlConnector.fetchCodeList(CodeListCode(equalTo("BC37")))(using any()))
+      .thenReturn(Future.successful(BC37Entries))
+    when(crdlConnector.fetchCodeList(CodeListCode(equalTo("BC66")))(using any()))
+      .thenReturn(Future.failed(UpstreamErrorResponse("Boom!", Status.INTERNAL_SERVER_ERROR)))
+    when(crdlConnector.fetchCodeList(CodeListCode(equalTo("E200")))(using any()))
+      .thenReturn(Future.successful(E200Entries))
+
+    // Mongo collection manipulation
+    when(codeListsRepository.saveCodeListEntries(equalTo(clientSession), any(), any()))
+      .thenReturn(Future.unit)
+    when(codeListsRepository.buildCnCodes(equalTo(clientSession)))
+      .thenReturn(Future.successful(CnCodes))
+    when(codeListsRepository.buildExciseProducts(equalTo(clientSession)))
+      .thenReturn(Future.successful(ExciseProducts))
+    when(exciseProductsRepository.saveExciseProducts(equalTo(clientSession), any()))
+      .thenReturn(Future.unit)
+    when(cnCodesRepository.saveCnCodes(equalTo(clientSession), any())).thenReturn(Future.unit)
+
+    refDataJob.importReferenceData().failed.futureValue shouldBe an[UpstreamErrorResponse]
+
+    verify(codeListsRepository, times(3)).saveCodeListEntries(equalTo(clientSession), any(), any())
+    verify(cnCodesRepository, times(1)).saveCnCodes(equalTo(clientSession), any())
+    verify(exciseProductsRepository, never()).saveExciseProducts(equalTo(clientSession), any())
+
+    verify(clientSession, times(1)).abortTransaction()
+  }
+
+  it should "roll back and fail to build CN codes when there is an issue fetching one of the required codelists" in {
+    // CRDL connector responses
+    when(crdlConnector.fetchCodeList(CodeListCode(equalTo("BC36")))(using any()))
+      .thenReturn(Future.successful(BC36Entries))
+    when(crdlConnector.fetchCodeList(CodeListCode(equalTo("BC37")))(using any()))
+      .thenReturn(Future.successful(BC37Entries))
+    when(crdlConnector.fetchCodeList(CodeListCode(equalTo("BC66")))(using any()))
+      .thenReturn(Future.successful(BC66Entries))
+    when(crdlConnector.fetchCodeList(CodeListCode(equalTo("E200")))(using any()))
+      .thenReturn(Future.failed(UpstreamErrorResponse("Boom!", Status.INTERNAL_SERVER_ERROR)))
+
+    // Mongo collection manipulation
+    when(codeListsRepository.saveCodeListEntries(equalTo(clientSession), any(), any()))
+      .thenReturn(Future.unit)
+    when(codeListsRepository.buildCnCodes(equalTo(clientSession)))
+      .thenReturn(Future.successful(CnCodes))
+    when(codeListsRepository.buildExciseProducts(equalTo(clientSession)))
+      .thenReturn(Future.successful(ExciseProducts))
+    when(exciseProductsRepository.saveExciseProducts(equalTo(clientSession), any()))
+      .thenReturn(Future.unit)
+    when(cnCodesRepository.saveCnCodes(equalTo(clientSession), any())).thenReturn(Future.unit)
+
+    refDataJob.importReferenceData().failed.futureValue shouldBe an[UpstreamErrorResponse]
+
+    verify(codeListsRepository, times(3)).saveCodeListEntries(equalTo(clientSession), any(), any())
+    verify(cnCodesRepository, never()).saveCnCodes(equalTo(clientSession), any())
+    verify(exciseProductsRepository, times(1)).saveExciseProducts(equalTo(clientSession), any())
+
+    verify(clientSession, times(1)).abortTransaction()
+  }
+
+  it should "roll back and fail to build either domain object when there is an issue fetching the excise products codelist" in {
+    // CRDL connector responses
+    when(crdlConnector.fetchCodeList(CodeListCode(equalTo("BC36")))(using any()))
+      .thenReturn(Future.failed(UpstreamErrorResponse("Boom!", Status.INTERNAL_SERVER_ERROR)))
+    when(crdlConnector.fetchCodeList(CodeListCode(equalTo("BC37")))(using any()))
+      .thenReturn(Future.successful(BC37Entries))
+    when(crdlConnector.fetchCodeList(CodeListCode(equalTo("BC66")))(using any()))
+      .thenReturn(Future.successful(BC66Entries))
+    when(crdlConnector.fetchCodeList(CodeListCode(equalTo("E200")))(using any()))
+      .thenReturn(Future.successful(E200Entries))
+
+    // Mongo collection manipulation
+    when(codeListsRepository.saveCodeListEntries(equalTo(clientSession), any(), any()))
+      .thenReturn(Future.unit)
+    when(codeListsRepository.buildCnCodes(equalTo(clientSession)))
+      .thenReturn(Future.successful(CnCodes))
+    when(codeListsRepository.buildExciseProducts(equalTo(clientSession)))
+      .thenReturn(Future.successful(ExciseProducts))
+    when(exciseProductsRepository.saveExciseProducts(equalTo(clientSession), any()))
+      .thenReturn(Future.unit)
+    when(cnCodesRepository.saveCnCodes(equalTo(clientSession), any())).thenReturn(Future.unit)
+
+    refDataJob.importReferenceData().failed.futureValue shouldBe an[UpstreamErrorResponse]
+
+    verify(codeListsRepository, times(3)).saveCodeListEntries(equalTo(clientSession), any(), any())
+    verify(cnCodesRepository, never()).saveCnCodes(equalTo(clientSession), any())
+    verify(exciseProductsRepository, never()).saveExciseProducts(equalTo(clientSession), any())
+
+    verify(clientSession, times(1)).abortTransaction()
+  }
+
+  it should "roll back when there is an issue saving the excise products" in {
+    // CRDL connector responses
+    when(crdlConnector.fetchCodeList(CodeListCode(equalTo("BC36")))(using any()))
+      .thenReturn(Future.successful(BC36Entries))
+    when(crdlConnector.fetchCodeList(CodeListCode(equalTo("BC37")))(using any()))
+      .thenReturn(Future.successful(BC37Entries))
+    when(crdlConnector.fetchCodeList(CodeListCode(equalTo("BC66")))(using any()))
+      .thenReturn(Future.successful(BC66Entries))
+    when(crdlConnector.fetchCodeList(CodeListCode(equalTo("E200")))(using any()))
+      .thenReturn(Future.successful(E200Entries))
+
+    // Mongo collection manipulation
+    when(codeListsRepository.saveCodeListEntries(equalTo(clientSession), any(), any()))
+      .thenReturn(Future.unit)
+    when(codeListsRepository.buildCnCodes(equalTo(clientSession)))
+      .thenReturn(Future.successful(CnCodes))
+    when(codeListsRepository.buildExciseProducts(equalTo(clientSession)))
+      .thenReturn(Future.successful(ExciseProducts))
+    when(exciseProductsRepository.saveExciseProducts(equalTo(clientSession), any()))
+      .thenReturn(Future.failed(MongoError.NotAcknowledged))
+    when(cnCodesRepository.saveCnCodes(equalTo(clientSession), any())).thenReturn(Future.unit)
+
+    refDataJob.importReferenceData().failed.futureValue shouldBe a[MongoError]
+
+    verify(codeListsRepository, times(4)).saveCodeListEntries(equalTo(clientSession), any(), any())
+    verify(cnCodesRepository, times(1)).saveCnCodes(equalTo(clientSession), any())
+    verify(exciseProductsRepository, times(1)).saveExciseProducts(equalTo(clientSession), any())
+
+    verify(clientSession, times(1)).abortTransaction()
+  }
+
+  it should "roll back when there is an issue saving the CN codes" in {
+    // CRDL connector responses
+    when(crdlConnector.fetchCodeList(CodeListCode(equalTo("BC36")))(using any()))
+      .thenReturn(Future.successful(BC36Entries))
+    when(crdlConnector.fetchCodeList(CodeListCode(equalTo("BC37")))(using any()))
+      .thenReturn(Future.successful(BC37Entries))
+    when(crdlConnector.fetchCodeList(CodeListCode(equalTo("BC66")))(using any()))
+      .thenReturn(Future.successful(BC66Entries))
+    when(crdlConnector.fetchCodeList(CodeListCode(equalTo("E200")))(using any()))
+      .thenReturn(Future.successful(E200Entries))
+
+    // Mongo collection manipulation
+    when(codeListsRepository.saveCodeListEntries(equalTo(clientSession), any(), any()))
+      .thenReturn(Future.unit)
+    when(codeListsRepository.buildCnCodes(equalTo(clientSession)))
+      .thenReturn(Future.successful(CnCodes))
+    when(codeListsRepository.buildExciseProducts(equalTo(clientSession)))
+      .thenReturn(Future.successful(ExciseProducts))
+    when(exciseProductsRepository.saveExciseProducts(equalTo(clientSession), any()))
+      .thenReturn(Future.unit)
+    when(cnCodesRepository.saveCnCodes(equalTo(clientSession), any()))
+      .thenReturn(Future.failed(MongoError.NotAcknowledged))
+
+    refDataJob.importReferenceData().failed.futureValue shouldBe a[MongoError]
+
+    verify(codeListsRepository, times(4)).saveCodeListEntries(equalTo(clientSession), any(), any())
+    verify(cnCodesRepository, times(1)).saveCnCodes(equalTo(clientSession), any())
+    verify(exciseProductsRepository, times(1)).saveExciseProducts(equalTo(clientSession), any())
+
+    verify(clientSession, times(1)).abortTransaction()
+  }
+}

--- a/test/uk/gov/hmrc/emcstfereferencedata/support/UnitSpec.scala
+++ b/test/uk/gov/hmrc/emcstfereferencedata/support/UnitSpec.scala
@@ -21,13 +21,30 @@ import org.scalatest.EitherValues
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
-import play.api.test.{DefaultAwaitTimeout, FutureAwaits}
+import play.api.Application
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.test.DefaultAwaitTimeout
+import play.api.test.FutureAwaits
+import uk.gov.hmrc.emcstfereferencedata.config.SchedulerModule
 import uk.gov.hmrc.http.HeaderCarrier
 
 import scala.concurrent.ExecutionContext
 
-trait UnitSpec extends AnyWordSpecLike with MockFactory with EitherValues with Matchers with FutureAwaits with DefaultAwaitTimeout with GuiceOneAppPerSuite {
-  implicit lazy val hc: HeaderCarrier = HeaderCarrier()
-  implicit lazy val ec: ExecutionContext = app.injector.instanceOf[ExecutionContext]
-}
+trait UnitSpec
+  extends AnyWordSpecLike
+  with MockFactory
+  with EitherValues
+  with Matchers
+  with FutureAwaits
+  with DefaultAwaitTimeout
+  with GuiceOneAppPerSuite {
+  implicit lazy val hc: HeaderCarrier    = HeaderCarrier()
+  implicit lazy val ec: ExecutionContext = ExecutionContext.global
 
+  override def fakeApplication(): Application = {
+    GuiceApplicationBuilder()
+      // Stop Quartz from complaining about being instantiated multiple times
+      .disable(classOf[SchedulerModule])
+      .build()
+  }
+}


### PR DESCRIPTION
This PR adds a daily migration job which rebuilds the CN codes and excise products collections.

It does this by fetching the BC36 (excise products), BC37 (CN codes), BC66 (excise product categories) and E200 (CN code <-> excise products correspondence) codelists from crdl-cache, then using the `buildExciseProducts` and `buildCnCodes` Mongo aggregations in order to build the composite `CnCodeInformation` and `ExciseProductCode` domain objects.