### PR TITLE
CRDL-376 Change the default port for the service to match the new service-manager config

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ lazy val microservice = (project in file("."))
   .settings(
     name := appName,
     libraryDependencies ++= AppDependencies(),
-    PlayKeys.playDefaultPort := 8312,
+    PlayKeys.playDefaultPort := 8321,
     // Change classloader layering to avert classloading issues
     Compile / classLoaderLayeringStrategy := ClassLoaderLayeringStrategy.Flat,
     scalacOptions ++= Seq(


### PR DESCRIPTION
The port for the service will be set to 8321 (the next free port in the 83xx range) in the service manager config in hmrc/service-manager-config#7061.

This PR changes the port that the service uses when running locally in sbt to match.