### PR TITLE
CRDL-396 Fix an exception when looking up data across codelists fails

### DIFF
--- a/app/uk/gov/hmrc/emcstfereferencedata/models/response/CnCodeMapping.scala
+++ b/app/uk/gov/hmrc/emcstfereferencedata/models/response/CnCodeMapping.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.emcstfereferencedata.models.response
+
+import play.api.libs.json.Format
+import play.api.libs.json.Json
+
+case class CnCodeMapping(
+  cnCode: String,
+  cnCodeDescription: Option[String],
+  exciseProductCode: String,
+  exciseProductCodeDescription: Option[String],
+  unitOfMeasureCode: Option[Int]
+)
+
+object CnCodeMapping {
+  val mongoFormat: Format[CnCodeMapping] = Json.format[CnCodeMapping]
+}

--- a/app/uk/gov/hmrc/emcstfereferencedata/models/response/CnCodeMapping.scala
+++ b/app/uk/gov/hmrc/emcstfereferencedata/models/response/CnCodeMapping.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.emcstfereferencedata.models.response
 
-import play.api.libs.json.Format
+import play.api.libs.json.OFormat
 import play.api.libs.json.Json
 
 case class CnCodeMapping(
@@ -28,5 +28,5 @@ case class CnCodeMapping(
 )
 
 object CnCodeMapping {
-  val mongoFormat: Format[CnCodeMapping] = Json.format[CnCodeMapping]
+  given mongoFormat: OFormat[CnCodeMapping] = Json.format[CnCodeMapping]
 }

--- a/app/uk/gov/hmrc/emcstfereferencedata/models/response/ExciseProductMapping.scala
+++ b/app/uk/gov/hmrc/emcstfereferencedata/models/response/ExciseProductMapping.scala
@@ -28,5 +28,5 @@ case class ExciseProductMapping(
 )
 
 object ExciseProductMapping {
-  val mongoFormat: OFormat[ExciseProductMapping] = Json.format[ExciseProductMapping]
+  given mongoFormat: OFormat[ExciseProductMapping] = Json.format[ExciseProductMapping]
 }

--- a/app/uk/gov/hmrc/emcstfereferencedata/models/response/ExciseProductMapping.scala
+++ b/app/uk/gov/hmrc/emcstfereferencedata/models/response/ExciseProductMapping.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.emcstfereferencedata.models.response
+
+import play.api.libs.json.OFormat
+import play.api.libs.json.Json
+
+case class ExciseProductMapping(
+  code: String,
+  description: String,
+  category: String,
+  categoryDescription: Option[String],
+  unitOfMeasureCode: Option[Int]
+)
+
+object ExciseProductMapping {
+  val mongoFormat: OFormat[ExciseProductMapping] = Json.format[ExciseProductMapping]
+}

--- a/app/uk/gov/hmrc/emcstfereferencedata/repositories/CodeListsRepository.scala
+++ b/app/uk/gov/hmrc/emcstfereferencedata/repositories/CodeListsRepository.scala
@@ -27,13 +27,19 @@ import play.api.libs.json.*
 import uk.gov.hmrc.emcstfereferencedata.models.crdl.{CodeListCode, CrdlCodeListEntry}
 import uk.gov.hmrc.emcstfereferencedata.models.errors.MongoError
 import uk.gov.hmrc.emcstfereferencedata.models.mongo.CodeListEntry
-import uk.gov.hmrc.emcstfereferencedata.models.response.{CnCodeInformation, ExciseProductCode}
+import uk.gov.hmrc.emcstfereferencedata.models.response.{
+  CnCodeInformation,
+  CnCodeMapping,
+  ExciseProductCode,
+  ExciseProductMapping
+}
 import uk.gov.hmrc.mongo.MongoComponent
 import uk.gov.hmrc.mongo.play.json.{Codecs, PlayMongoRepository}
 import uk.gov.hmrc.mongo.transaction.Transactions
 
 import javax.inject.{Inject, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
+import uk.gov.hmrc.emcstfereferencedata.utils.Logging
 
 @Singleton
 class CodeListsRepository @Inject() (val mongoComponent: MongoComponent)(using ec: ExecutionContext)
@@ -46,7 +52,9 @@ class CodeListsRepository @Inject() (val mongoComponent: MongoComponent)(using e
         Codecs.playFormatSumCodecs[JsBoolean](Format(Reads.JsBooleanReads, Writes.jsValueWrites)) ++
         Seq(
           Codecs.playFormatCodec(ExciseProductCode.mongoFormat),
-          Codecs.playFormatCodec(CnCodeInformation.mongoFormat)
+          Codecs.playFormatCodec(ExciseProductMapping.mongoFormat),
+          Codecs.playFormatCodec(CnCodeInformation.mongoFormat),
+          Codecs.playFormatCodec(CnCodeMapping.mongoFormat)
         ),
     indexes = Seq(
       IndexModel(
@@ -56,7 +64,8 @@ class CodeListsRepository @Inject() (val mongoComponent: MongoComponent)(using e
       IndexModel(Indexes.ascending("codeListCode"))
     )
   )
-  with Transactions {
+  with Transactions
+  with Logging {
 
   // This collection's entries are cleared every time new codelists are imported
   override lazy val requiresTtlIndex: Boolean = false
@@ -107,7 +116,7 @@ class CodeListsRepository @Inject() (val mongoComponent: MongoComponent)(using e
 
   def buildCnCodes(session: ClientSession): Future[Seq[CnCodeInformation]] = {
     collection
-      .aggregate[CnCodeInformation](
+      .aggregate[CnCodeMapping](
         session,
         List(
           // Find the CN code <-> excise product mappings
@@ -151,12 +160,33 @@ class CodeListsRepository @Inject() (val mongoComponent: MongoComponent)(using e
           )
         )
       )
+      .flatMap { cnCodeMapping =>
+        val cnCodeInfo = for {
+          cnCodeDescription            <- cnCodeMapping.cnCodeDescription
+          exciseProductCodeDescription <- cnCodeMapping.exciseProductCodeDescription
+          unitOfMeasureCode            <- cnCodeMapping.unitOfMeasureCode
+        } yield CnCodeInformation(
+          cnCodeMapping.cnCode,
+          cnCodeDescription,
+          cnCodeMapping.exciseProductCode,
+          exciseProductCodeDescription,
+          unitOfMeasureCode
+        )
+
+        cnCodeInfo.getOrElse {
+          logger.warn(
+            s"Unable to retrieve all of the required CN code information for CN code ${cnCodeMapping.cnCode} and excise product ${cnCodeMapping.exciseProductCode}: ${cnCodeMapping}"
+          )
+        }
+
+        Observable(cnCodeInfo.toList)
+      }
       .toFuture()
   }
 
   def buildExciseProducts(session: ClientSession): Future[Seq[ExciseProductCode]] = {
     collection
-      .aggregate[ExciseProductCode](
+      .aggregate[ExciseProductMapping](
         session,
         List(
           // Find the excise products
@@ -173,11 +203,8 @@ class CodeListsRepository @Inject() (val mongoComponent: MongoComponent)(using e
               computed("code", "$key"),
               // Include the excise product value as "description"
               computed("description", "$value"),
-              computed(
-                // Get the "category" from the nested "productCategory" doc's key
-                "category",
-                getFieldOf("key", arrayField = "productCategory")
-              ),
+              // Include the excise product category as "category"
+              computed("category", "$properties.exciseProductsCategoryCode"),
               computed(
                 // Get the "categoryDescription" from the nested "productCategory" doc's value
                 "categoryDescription",
@@ -189,6 +216,26 @@ class CodeListsRepository @Inject() (val mongoComponent: MongoComponent)(using e
           )
         )
       )
+      .flatMap { exciseProductMapping =>
+        val exciseProduct = for {
+          categoryDescription <- exciseProductMapping.categoryDescription
+          unitOfMeasureCode   <- exciseProductMapping.unitOfMeasureCode
+        } yield ExciseProductCode(
+          exciseProductMapping.code,
+          exciseProductMapping.description,
+          exciseProductMapping.category,
+          categoryDescription,
+          unitOfMeasureCode
+        )
+
+        exciseProduct.getOrElse {
+          logger.warn(
+            s"Unable to retrieve excise product category information for excise product ${exciseProductMapping.code}: ${exciseProductMapping}"
+          )
+        }
+
+        Observable(exciseProduct.toList)
+      }
       .toFuture()
   }
 

--- a/it/test/uk/gov/hmrc/emcstfereferencedata/repositories/CodeListsRepositorySpec.scala
+++ b/it/test/uk/gov/hmrc/emcstfereferencedata/repositories/CodeListsRepositorySpec.scala
@@ -160,6 +160,19 @@ class CodeListsRepositorySpec
           "E440",
           Json.obj("actionIdentification" -> "2413")
         ),
+        // CN Codes <-> Excise Products entries that don't correspond to any existing excise products
+        CodeListEntry(
+          cnCodesToExciseProductsCode,
+          "22123127",
+          "X999",
+          Json.obj("actionIdentification" -> "2414")
+        ),
+        CodeListEntry(
+          cnCodesToExciseProductsCode,
+          "22398478",
+          "Y999",
+          Json.obj("actionIdentification" -> "2414")
+        ),
         // CN Codes
         CodeListEntry(
           cnCodesCode,
@@ -357,6 +370,7 @@ class CodeListsRepositorySpec
       val categoriesCode = CodeListCode("BC66")
 
       val codeListEntries = Seq(
+        // Excise product categories
         CodeListEntry(
           categoriesCode,
           "B",
@@ -369,6 +383,7 @@ class CodeListsRepositorySpec
           "Energy Products",
           Json.obj("actionIdentification" -> "1085")
         ),
+        // Excise products
         CodeListEntry(
           productsCode,
           "B000",
@@ -404,6 +419,20 @@ class CodeListsRepositorySpec
             "degreePlatoApplicabilityFlag"       -> false,
             "actionIdentification"               -> "1098",
             "exciseProductsCategoryCode"         -> "E",
+            "alcoholicStrengthApplicabilityFlag" -> false,
+            "densityApplicabilityFlag"           -> true
+          )
+        ),
+        // Excise products that don't correspond to any known category codes
+        CodeListEntry(
+          productsCode,
+          "L460",
+          "Kerosene, marked falling within CN code 2710 19 25 (Article 20(1)(c) of Directive 2003/96/EC)",
+          Json.obj(
+            "unitOfMeasureCode"                  -> "2",
+            "degreePlatoApplicabilityFlag"       -> false,
+            "actionIdentification"               -> "1099",
+            "exciseProductsCategoryCode"         -> "L",
             "alcoholicStrengthApplicabilityFlag" -> false,
             "densityApplicabilityFlag"           -> true
           )

--- a/test/uk/gov/hmrc/emcstfereferencedata/models/response/CnCodeMappingSpec.scala
+++ b/test/uk/gov/hmrc/emcstfereferencedata/models/response/CnCodeMappingSpec.scala
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.emcstfereferencedata.models.response
+
+import play.api.libs.json.Json
+import uk.gov.hmrc.emcstfereferencedata.support.UnitSpec
+
+class CnCodeMappingSpec extends UnitSpec {
+
+  private val testCommodityCodeTobacco = CnCodeMapping(
+    cnCode = "24029000",
+    cnCodeDescription = Some("Cigarettes containing tobacco / other"),
+    exciseProductCode = "T400",
+    exciseProductCodeDescription = Some("Cigarettes"),
+    unitOfMeasureCode = Some(1)
+  )
+
+  private val testNoOptionalFields = CnCodeMapping(
+    cnCode = "24029000",
+    cnCodeDescription = None,
+    exciseProductCode = "T400",
+    exciseProductCodeDescription = None,
+    unitOfMeasureCode = None
+  )
+
+  "reads" should {
+    "read JSON to a model" in {
+      Json
+        .obj(
+          "cnCode"                       -> "24029000",
+          "cnCodeDescription"            -> "Cigarettes containing tobacco / other",
+          "exciseProductCode"            -> "T400",
+          "exciseProductCodeDescription" -> "Cigarettes",
+          "unitOfMeasureCode"            -> 1
+        )
+        .as[CnCodeMapping] shouldBe testCommodityCodeTobacco
+    }
+
+    "read JSON to a model with optional fields missing" in {
+      Json
+        .obj(
+          "cnCode"            -> "24029000",
+          "exciseProductCode" -> "T400"
+        )
+        .as[CnCodeMapping] shouldBe testNoOptionalFields
+    }
+  }
+
+  "writes" should {
+    "write JSON to a model" in {
+      Json.toJson(testCommodityCodeTobacco) shouldBe Json.obj(
+        "cnCode"                       -> "24029000",
+        "cnCodeDescription"            -> "Cigarettes containing tobacco / other",
+        "exciseProductCode"            -> "T400",
+        "exciseProductCodeDescription" -> "Cigarettes",
+        "unitOfMeasureCode"            -> 1
+      )
+    }
+
+    "write JSON with no optional fields to a model" in {
+      Json.toJson(testNoOptionalFields) shouldBe Json.obj(
+        "cnCode"            -> "24029000",
+        "exciseProductCode" -> "T400"
+      )
+    }
+  }
+}

--- a/test/uk/gov/hmrc/emcstfereferencedata/models/response/ExciseProductMappingSpec.scala
+++ b/test/uk/gov/hmrc/emcstfereferencedata/models/response/ExciseProductMappingSpec.scala
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.emcstfereferencedata.models.response
+
+import play.api.libs.json.Json
+import uk.gov.hmrc.emcstfereferencedata.support.UnitSpec
+
+class ExciseProductMappingSpec extends UnitSpec {
+
+  val wineExciseProductCode = ExciseProductMapping(
+    code = "W200",
+    description = "Still wine and still fermented beverages other than wine and beer",
+    category = "W",
+    categoryDescription = Some("Wine and fermented beverages other than wine and beer"),
+    unitOfMeasureCode = Some(3)
+  )
+
+  val wineNoOptionalFields = ExciseProductMapping(
+    code = "W200",
+    description = "Still wine and still fermented beverages other than wine and beer",
+    category = "W",
+    categoryDescription = None,
+    unitOfMeasureCode = None
+  )
+
+  "reads" should {
+    "read JSON to a model" in {
+      Json
+        .obj(
+          "code"        -> "W200",
+          "description" -> "Still wine and still fermented beverages other than wine and beer",
+          "category"    -> "W",
+          "categoryDescription" -> "Wine and fermented beverages other than wine and beer",
+          "unitOfMeasureCode"   -> 3
+        )
+        .as[ExciseProductMapping] shouldBe wineExciseProductCode
+    }
+
+    "read JSON to a model with optional fields missing" in {
+      Json
+        .obj(
+          "code"        -> "W200",
+          "description" -> "Still wine and still fermented beverages other than wine and beer",
+          "category"    -> "W"
+        )
+        .as[ExciseProductMapping] shouldBe wineNoOptionalFields
+    }
+  }
+
+  "writes" should {
+    "write JSON to a model" in {
+      Json.toJson(wineExciseProductCode) shouldBe Json.obj(
+        "code"        -> "W200",
+        "description" -> "Still wine and still fermented beverages other than wine and beer",
+        "category"    -> "W",
+        "categoryDescription" -> "Wine and fermented beverages other than wine and beer",
+        "unitOfMeasureCode"   -> 3
+      )
+    }
+
+    "write JSON with no optional fields to a model" in {
+      Json.toJson(wineNoOptionalFields) shouldBe Json.obj(
+        "code"        -> "W200",
+        "description" -> "Still wine and still fermented beverages other than wine and beer",
+        "category"    -> "W"
+      )
+    }
+  }
+}

--- a/test/uk/gov/hmrc/emcstfereferencedata/scheduler/jobs/ImportReferenceDataJobSpec.scala
+++ b/test/uk/gov/hmrc/emcstfereferencedata/scheduler/jobs/ImportReferenceDataJobSpec.scala
@@ -287,7 +287,7 @@ class ImportReferenceDataJobSpec
 
     verify(codeListsRepository, atLeastOnce()).saveCodeListEntries(equalTo(clientSession), any(), any())
     verify(cnCodesRepository, never()).saveCnCodes(equalTo(clientSession), any())
-    verify(exciseProductsRepository, times(1)).saveExciseProducts(equalTo(clientSession), any())
+    verify(exciseProductsRepository, never()).saveExciseProducts(equalTo(clientSession), any())
 
     verify(clientSession, times(1)).abortTransaction()
   }
@@ -316,7 +316,7 @@ class ImportReferenceDataJobSpec
 
     refDataJob.importReferenceData().failed.futureValue shouldBe an[UpstreamErrorResponse]
 
-    verify(codeListsRepository, atLeastOnce()).saveCodeListEntries(equalTo(clientSession), any(), any())
+    verify(codeListsRepository, never()).saveCodeListEntries(equalTo(clientSession), any(), any())
     verify(cnCodesRepository, never()).saveCnCodes(equalTo(clientSession), any())
     verify(exciseProductsRepository, never()).saveExciseProducts(equalTo(clientSession), any())
 


### PR DESCRIPTION
We encountered an issue when an entry exists in the E200 (CN Codes <-> Excise Products) correspondence list that doesn't actually exist in the underlying BC36 (Excise Products) list.

We've altered our logic slightly to enable such lookups to fail gracefully and log missing data.

We also encountered issues with MongoDB observing writes out of order.

Unfortunately it doesn't seem that Mongo can handle multiple concurrent reads and writes in the same transaction.

We have resolved this by refactoring the import job to read and write data sequentially.