### PR TITLE
CRDL-424: Update schedule config for agreed platform runtimes

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -69,7 +69,7 @@ internal-auth {
 }
 
 import-reference-data {
-  schedule = "0 30 4 * * ?"
+  schedule = "0 45 23 ? * Tue"
 }
 
 microservice {


### PR DESCRIPTION
In line with the requested platform wide scheduling for CRDL data, we are updating the CRDL Cache to import data at the following times:

EMCS TFE queries: every Tuesday at 23:45
This is 15 minutes after the CRDL Cache is set to update, which this relies upon so will follow on to pick up anything new.